### PR TITLE
Make `to_string()` more efficient by utilizing batch processing

### DIFF
--- a/src/bi.cpp
+++ b/src/bi.cpp
@@ -893,12 +893,25 @@ std::string bi_t::to_string() const {
   const size_t estimate = h_::decimal_length(*this);
   bi_t copy = *this;
   std::string result;
-
   result.reserve(estimate);
 
+  constexpr digit divisor = powers_of_ten[max_batch_size];
+
   while (copy.size()) {
-    int digit = h_::idiv10(copy);
-    result.push_back(static_cast<char>('0' + digit));
+    digit remainder = h_::div_algo_digit(copy, copy, divisor);
+
+    for (size_t i = 0; i < max_batch_size; ++i) {
+      if (remainder == 0 && copy.size() == 0) {
+        break;
+      }
+
+      // NOLINTBEGIN(cppcoreguidelines-avoid-magic-numbers)
+      digit current_digit = remainder % 10;
+      remainder /= 10;
+      // NOLINTEND(cppcoreguidelines-avoid-magic-numbers)
+
+      result.push_back(static_cast<char>('0' + current_digit));
+    }
   }
 
   if (negative_) {

--- a/src/h_.hpp
+++ b/src/h_.hpp
@@ -39,6 +39,7 @@ struct h_ {
   // multiplicative
   static void imul1add1(bi_t& x, digit v, digit k);
   static void mul(bi_t& result, const bi_t& a, const bi_t& b);
+  static digit div_algo_digit(bi_t& q, const bi_t& u, digit v) noexcept;
   static void div_algo_single(bi_t& q, bi_t& r, const bi_t& n,
                               const bi_t& d) noexcept;
   static void div_algo_binary(bi_t& q, bi_t& r, const bi_t& n, const bi_t& d);
@@ -465,6 +466,19 @@ void h_::mul(bi_t& result, const bi_t& a, const bi_t& b) {
 /**
  *  NOTE: Assumes space and size have already been set for q and r.
  */
+digit h_::div_algo_digit(bi_t& q, const bi_t& u, digit v) noexcept {
+  ddigit rem{0};
+
+  for (size_t j = u.size() - 1; j < std::numeric_limits<size_t>::max(); --j) {
+    const ddigit temp = (rem << bi_dwidth) | u[j];  // rem * bi_base + u[j]
+    q[j] = temp / v;
+    rem = temp % v;
+  }
+
+  q.trim_trailing_zeros();
+  return static_cast<digit>(rem);
+}
+
 void h_::div_algo_single(bi_t& q, bi_t& r, const bi_t& u,
                          const bi_t& v) noexcept {
   ddigit rem{0};


### PR DESCRIPTION
This makes a big difference for large integers.